### PR TITLE
Upgrade to 2.2.6

### DIFF
--- a/INFO.sh
+++ b/INFO.sh
@@ -3,7 +3,7 @@
 . /pkgscripts/include/pkg_util.sh
 
 package="zfs"
-version="2.2.5-0001"
+version="2.2.6-0001"
 os_min_ver="7.0-40761"
 description="OpenZFS is storage software which combines the functionality of traditional filesystems, volume manager, and more."
 arch="$(pkg_get_platform)"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 include /env.mak
 
 LINUX := $(SysRootLib)/modules/DSM-$(DSM_SHLIB_MAJOR).$(DSM_SHLIB_MINOR)/build
-ZFS := zfs-2.2.5
+ZFS := zfs-2.2.6
 
 .PHONY: all install packageinstall $(ZFS)
 

--- a/scripts/postinst
+++ b/scripts/postinst
@@ -17,7 +17,7 @@ $MKDIR_P /etc/default /etc/exports.d
 $CP_A --preserve=links $SYNOPKG_PKGDEST/usr/lib/systemd/system/* /usr/lib/systemd/system/
 
 for m in $(find $SYNOPKG_PKGDEST/lib/modules -type f); do
-    $LN_S $m /lib/modules/asd
+    $LN_S $m /lib/modules/${m##*/}
 done
 
 $LN_S $SYNOPKG_PKGDEST/etc/default/* /etc/default/

--- a/scripts/postinst
+++ b/scripts/postinst
@@ -35,7 +35,7 @@ systemctl enable pkg-zfs-load-spl-ko.service pkg-zfs-load-zfs-ko.service zfs-imp
 
 # Workaround for zfs not supporting syno_recvfile
 # https://github.com/jberkman/synozfs/issues/4
-if [ -s ${SMBCONF} ] && ! grep -q "min receivefile size" ${SMBCONF}
+if [ -s ${SMBCONF} ] && ! grep -q "min receivefile size" ${SMBCONF}; then
     printf '\tmin receivefile size = 0\n' >> ${SMBCONF}
     killall -HUP smbd
 fi


### PR DESCRIPTION
This upgrades ZFS to 2.2.6 which works on the 4.4.x kernel on some devices.

2.2.7 doesn't work on 4.4.x as it has dependencies on API calls only supported on newer kernels.